### PR TITLE
FIX: switch to basic-topic-list

### DIFF
--- a/javascripts/discourse/components/portfolio-basic-topic-list.js
+++ b/javascripts/discourse/components/portfolio-basic-topic-list.js
@@ -1,4 +1,0 @@
-import BasicTopicList from "discourse/components/basic-topic-list";
-// Hack to work around https://github.com/discourse/discourse/pull/10105
-// Can be removed once the PR is merged to core
-export default BasicTopicList;

--- a/javascripts/discourse/templates/user-portfolio.hbs
+++ b/javascripts/discourse/templates/user-portfolio.hbs
@@ -5,7 +5,7 @@
       selector=".paginated-topics-list .topic-list tr"
       action=(action "loadMore")
     }}
-      {{portfolio-basic-topic-list topicList=model showPosters=true}}
+      {{basic-topic-list topicList=model showPosters=true}}
       {{conditional-loading-spinner condition=model.loadingMore}}
     {{/load-more}}
   {{else}}


### PR DESCRIPTION
This fixes the issue that was causing the user's portfolio page to be blank, as reported here: https://meta.discourse.org/t/user-portfolio-theme-component/156678/9?u=awesomerobot