### PR TITLE
UX: fix link for user menu, add requested settings

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -17,3 +17,10 @@
     text-align: center;
   }
 }
+
+.user-card {
+  .portfolio-link {
+    min-width: 10em;
+    width: 100%;
+  }
+}

--- a/common/common.scss
+++ b/common/common.scss
@@ -17,10 +17,3 @@
     text-align: center;
   }
 }
-
-.user-card {
-  .portfolio-link {
-    min-width: 10em;
-    width: 100%;
-  }
-}

--- a/common/common.scss
+++ b/common/common.scss
@@ -1,9 +1,3 @@
-.user-portfolio {
-  grid-row-start: 2;
-  grid-row-end: 4;
-  grid-column-start: 1;
-  grid-column-end: 3;
-}
 .empty-portfolio {
   display: flex;
   flex-direction: column;
@@ -11,9 +5,9 @@
   align-items: center;
 
   .empty-portfolio-message {
-    margin: 20px;
+    margin-top: 2em;
     font-size: $font-up-2;
-    max-width: 500px;
+    max-width: 30em;
     text-align: center;
   }
 }

--- a/javascripts/discourse/connectors/user-card-additional-buttons/portfolio-link.hbs
+++ b/javascripts/discourse/connectors/user-card-additional-buttons/portfolio-link.hbs
@@ -3,7 +3,8 @@
   href=(concat
     "/u/"
     user.username_lower
-    (concat "/activity/" (theme-setting "portfolio_route_name"))
+    "/activity/"
+    (theme-setting "portfolio_route_name")
   )
   icon=(theme-setting "portfolio_icon")
   label=(theme-prefix "portfolio")

--- a/javascripts/discourse/connectors/user-card-additional-buttons/portfolio-link.hbs
+++ b/javascripts/discourse/connectors/user-card-additional-buttons/portfolio-link.hbs
@@ -1,6 +1,10 @@
 {{d-button
   class="btn-default"
-  href=(concat "/u/" user.username_lower (concat "/activity/" (theme-setting "portfolio_route_name") ))
+  href=(concat
+    "/u/"
+    user.username_lower
+    (concat "/activity/" (theme-setting "portfolio_route_name"))
+  )
   icon=(theme-setting "portfolio_icon")
   label=(theme-prefix "portfolio")
 }}

--- a/javascripts/discourse/connectors/user-card-additional-buttons/portfolio-link.hbs
+++ b/javascripts/discourse/connectors/user-card-additional-buttons/portfolio-link.hbs
@@ -1,6 +1,6 @@
 {{d-button
   class="btn-default"
-  href=(concat "/u/" user.username_lower "/activity/portfolio")
+  href=(concat "/u/" user.username_lower (concat "/activity/" (theme-setting "portfolio_route_name") ))
   icon=(theme-setting "portfolio_icon")
   label=(theme-prefix "portfolio")
 }}

--- a/javascripts/discourse/connectors/user-main-nav/portfolio-link.hbs
+++ b/javascripts/discourse/connectors/user-main-nav/portfolio-link.hbs
@@ -1,3 +1,4 @@
 {{#link-to "user.portfolio"}}
   {{d-icon (theme-setting "portfolio_icon")}}
-  {{theme-i18n "portfolio"}}{{/link-to}}
+  <span>{{theme-i18n "portfolio"}}</span>
+{{/link-to}}

--- a/javascripts/discourse/portfolio-route-map.js
+++ b/javascripts/discourse/portfolio-route-map.js
@@ -1,6 +1,6 @@
 export default {
   resource: "user",
   map() {
-    this.route("portfolio", { path: "activity/portfolio" });
+    this.route("portfolio", { path: `activity/${settings.portfolio_route_name}` });
   },
 };

--- a/javascripts/discourse/portfolio-route-map.js
+++ b/javascripts/discourse/portfolio-route-map.js
@@ -1,6 +1,8 @@
 export default {
   resource: "user",
   map() {
-    this.route("portfolio", { path: `activity/${settings.portfolio_route_name}` });
+    this.route("portfolio", {
+      path: `activity/${settings.portfolio_route_name}`,
+    });
   },
 };

--- a/javascripts/discourse/routes/user-portfolio.js
+++ b/javascripts/discourse/routes/user-portfolio.js
@@ -18,7 +18,7 @@ export default DiscourseRoute.extend({
   model() {
     const filterParams = {};
     const filterTags = settings.portfolio_tags.replace(/\|/g, "+");
-    let tagQuery = filterTags ? `?tags=${filterTags}+` : "";
+    const tagQuery = filterTags ? `?tags=${filterTags}+` : "";
 
     if (settings.portfolio_category > 0) {
       filterParams["category"] = settings.portfolio_category;

--- a/javascripts/discourse/routes/user-portfolio.js
+++ b/javascripts/discourse/routes/user-portfolio.js
@@ -1,5 +1,3 @@
-const filterTags = settings.portfolio_tags.split("|").filter((val) => val);
-
 import DiscourseRoute from "discourse/routes/discourse";
 import Category from "discourse/models/category";
 
@@ -17,20 +15,19 @@ export default DiscourseRoute.extend({
     });
   },
 
-  model: function () {
+  model() {
     const filterParams = {};
+    const filterTags = settings.portfolio_tags.replace(/\|/g, "+");
+    let tagQuery = filterTags ? `?tags=${filterTags}+` : "";
 
     if (settings.portfolio_category > 0) {
       filterParams["category"] = settings.portfolio_category;
     }
 
-    if (filterTags.length > 0) {
-      filterParams["tags"] = filterTags;
-    }
+    filterParams["order"] = settings.portfolio_order;
 
     return this.store.findFiltered("topicList", {
-      filter:
-        "topics/created-by/" + this.modelFor("user").get("username_lower"),
+      filter: `topics/created-by/${this.modelFor("user").get("username_lower")}${tagQuery}`,
       params: filterParams,
     });
   },

--- a/javascripts/discourse/routes/user-portfolio.js
+++ b/javascripts/discourse/routes/user-portfolio.js
@@ -27,7 +27,9 @@ export default DiscourseRoute.extend({
     filterParams["order"] = settings.portfolio_order;
 
     return this.store.findFiltered("topicList", {
-      filter: `topics/created-by/${this.modelFor("user").get("username_lower")}${tagQuery}`,
+      filter: `topics/created-by/${this.modelFor("user").get(
+        "username_lower"
+      )}${tagQuery}`,
       params: filterParams,
     });
   },

--- a/javascripts/discourse/templates/user-portfolio.hbs
+++ b/javascripts/discourse/templates/user-portfolio.hbs
@@ -1,4 +1,4 @@
-<div class="user-portfolio">
+<div class="user-content user-portfolio">
   {{#if model.topics}}
     {{#load-more
       class="paginated-topics-list"
@@ -12,10 +12,14 @@
     <div class="empty-portfolio">
       <div class="empty-portfolio-message">
         {{html-safe (theme-i18n "empty_portfolio")}}
-
-        <a href={{category.url}}>
-          {{category.name}}
-        </a>
+        {{#if category}}
+          <p>
+            {{html-safe (theme-i18n "empty_portfolio_link")}}
+            <a href={{category.url}}>
+              {{category.name}}
+            </a>
+          </p>
+        {{/if}}
       </div>
     </div>
   {{/if}}

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -8,5 +8,5 @@ en:
       portfolio_thumbnail_style: Thumbnail style for portfolio page (requires discourse-topic-thumbnails to be installed and added to the active theme)
       user_card_portfolio_link: Display a portfolio link on user cards?
   portfolio: Portfolio
-  empty_portfolio: |
-    This portfolio is waiting to be filled<br/>Get started by adding topics to
+  empty_portfolio: This portfolio is waiting to be filled
+  empty_portfolio_link: Get started by adding topics to

--- a/settings.yml
+++ b/settings.yml
@@ -16,3 +16,14 @@ portfolio_thumbnail_style:
     - list
     - none
 user_card_portfolio_link: true
+portfolio_order:
+  default: "latest"
+  type: enum
+  choices:
+    - latest
+    - created
+portfolio_route_name: 
+  default: "portfolio"
+  type: string
+  description: |
+    name of the portfolio page in the URL, for example /u/username/activity/<strong>porfolio</strong>


### PR DESCRIPTION
Adds a `span` for the new user menu, so the text can be hidden in this situation

![Screenshot 2023-05-11 at 6 16 02 PM](https://github.com/discourse/discourse-user-portfolio/assets/1681963/0aa40b44-25ed-4d1b-9c3b-a7fb0d9eef36)

Adds some features requested from Meta:

* Allows admins to change the route name so they can optionally use `/u/username/activity/foo` instead of `/u/username/activity/portfolio`

* Updates the filter so multiple tags can be used to populate the portfolio 

* Adds a `portfolio_order` setting so the topic list can be ordered by latest or created