### PR TITLE
DEV: Resolve `link-to.positional-arguments` deprecation

### DIFF
--- a/javascripts/discourse/connectors/user-main-nav/portfolio-link.hbs
+++ b/javascripts/discourse/connectors/user-main-nav/portfolio-link.hbs
@@ -1,4 +1,4 @@
-{{#link-to "user.portfolio"}}
+{{#link-to route="user.portfolio"}}
   {{d-icon (theme-setting "portfolio_icon")}}
   <span>{{theme-i18n "portfolio"}}</span>
 {{/link-to}}


### PR DESCRIPTION
https://deprecations.emberjs.com/v3.x#toc_ember-glimmer-link-to-positional-arguments

This deprecation happens at build-time, which means it doesn't get surfaced like other deprecations in Discourse themes/plugins.